### PR TITLE
changing Django Admin headers

### DIFF
--- a/bartercheckout/admin.py
+++ b/bartercheckout/admin.py
@@ -14,6 +14,7 @@ class BarterAccountAdmin(admin.ModelAdmin):
 	"""
 	This is where you modify the view of a BarterAccount in the admin page.
 	"""
-
+admin.site.site_header = 'Sisters of the Road Cafe Admin'
+admin.site.index_title = 'Sisters of the Road Checkout Administration'
 admin.site.register(BarterAccount)
 admin.site.register(BarterEvent)


### PR DESCRIPTION
Hey all, sorry for the delay on this.  I was able to change the admin site header and login form header with 1 addition to admin.py (line 17).   I also customized the index header in line 18 - it used to read "Site Administration", but I thought it would be nice if that text also said something about Sisters of the Road.  If that's not needed, or we should use other wording there, let me know and I'll change it :) 