### PR TITLE
Customize the admin barter events list view

### DIFF
--- a/bartercheckout/admin.py
+++ b/bartercheckout/admin.py
@@ -6,14 +6,21 @@ from .models import BarterAccount
 
 
 class BarterEventAdmin(admin.ModelAdmin):
-	"""
-	This is where you modify the view of a BarterEvent in the admin page.
-	"""
+	list_display = [
+		'event_id',
+		'customer_name',
+		'event_type',
+		'event_time',
+		'transaction_amount',
+		]
 	
+	list_filter = ['event_type', 'event_time']
+
+	def event_id(self, obj):
+		return obj.id
+
+
 class BarterAccountAdmin(admin.ModelAdmin):
-	"""
-	This is where you modify the view of a BarterAccount in the admin page.
-	"""
 	list_display = ['customer_name', 'account_balance']
 	fields = ['customer_name','balance','last_add','last_subtract']
 	readonly_fields = ['last_add','last_subtract']
@@ -21,4 +28,4 @@ class BarterAccountAdmin(admin.ModelAdmin):
 admin.site.site_header = 'Sisters of the Road Cafe Admin'
 admin.site.index_title = 'Sisters of the Road Checkout Administration'
 admin.site.register(BarterAccount, BarterAccountAdmin)
-admin.site.register(BarterEvent)
+admin.site.register(BarterEvent, BarterEventAdmin) 

--- a/bartercheckout/models.py
+++ b/bartercheckout/models.py
@@ -32,16 +32,20 @@ class BarterEvent(models.Model):
 
     event_time = models.DateTimeField(auto_now_add=True)
     amount = models.IntegerField(default=0)
+
+    @property
+    def customer_name(self):
+        return self.barter_account.customer_name
+
+    @property
+    def transaction_amount(self):
+        assert type(self.amount) == int
+        return '${:,.2f}'.format(self.amount/100)
+
     #staff_id = models.ForeignKey()
+    
     def __str__(self):
-        if self.event_type == 'Add':
-            action = 'added to' 
-        else:
-            action = 'subtracted from'
-        message = '{} {} account on {}'.format(
-                self.barter_account.customer_name, action,
-                self.event_time.strftime("%Y-%m-%d %I:%M%p"))
-        return message
+        return 'Barter event ID {} for {}'.format(self.id, self.customer_name)
 
 
 class BarterAccount(models.Model):


### PR DESCRIPTION
@jarrighi I'm not sure about having the "Event ID" column in here. I don't think it's necessary and it required the addition of a method to customize the column name. (Because leaving it as ID might make it seem it's customer id, not event id.) Maybe we should check with Eileen whether they want the event id.